### PR TITLE
Extract interface localization helpers

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version: 6.0
 //
-// SuperDictate — a single-file Swift push-to-talk dictation app
+// SuperDictate — a Swift push-to-talk dictation app
 // for macOS Apple Silicon. Native AppKit / AVFoundation, FluidAudio
 // driving Parakeet TDT v3 on the Apple Neural Engine. macOS 14
 // (Sonoma) minimum. The Hardened Runtime microphone entitlement

--- a/swift/Sources/Parakey/Localization.swift
+++ b/swift/Sources/Parakey/Localization.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum InterfaceLanguage: String, CaseIterable {
+    case russian = "ru"
+    case english = "en"
+}
+
+func localizedText(_ russian: String,
+                   _ english: String,
+                   language: InterfaceLanguage) -> String {
+    language == .russian ? russian : english
+}

--- a/swift/Sources/Parakey/main.swift
+++ b/swift/Sources/Parakey/main.swift
@@ -1,7 +1,6 @@
 // Parakey — push-to-talk dictation for macOS Apple Silicon.
 //
-// Single-file Swift menu-bar app. The whole runtime lives in this
-// file: hotkey capture (`CGEventTap`), audio capture
+// Swift menu-bar app. The runtime covers hotkey capture (`CGEventTap`), audio capture
 // (`AVAudioEngine`), transcription (`FluidAudio` on the Apple
 // Neural Engine), paste-at-cursor (`NSPasteboard` + `CGEvent`),
 // system-audio mute (`NSAppleScript`), menu-bar UI, settings,
@@ -318,17 +317,6 @@ enum DictationCompletionBehavior: String, CaseIterable {
     }
 
     var pressesEnter: Bool { self == .insertAndEnter }
-}
-
-enum InterfaceLanguage: String, CaseIterable {
-    case russian = "ru"
-    case english = "en"
-}
-
-func localizedText(_ russian: String,
-                   _ english: String,
-                   language: InterfaceLanguage) -> String {
-    language == .russian ? russian : english
 }
 
 func localizedHotkeyName(_ choice: HotkeyChoice,


### PR DESCRIPTION
## What changed

- sync the contribution with the current `shlgd/main` (v0.2.36)
- move the independent `InterfaceLanguage` model and `localizedText` helper into `Localization.swift`
- keep hotkey localization in `main.swift` because it intentionally depends on file-private hotkey helpers
- update comments that described the app as single-file

## Why

The original draft moved all debug self-tests into another file and had to relax 119 file-private declarations to module-internal visibility. It also became stale as upstream added substantial fixes and new self-tests.

This revision keeps the modularization step deliberately small: it extracts only declarations that were already module-internal, changes no access control, and preserves the complete current upstream self-test suite.

## Impact

No intended user-facing behavior change. No `private` declaration is widened.

## Validation

- `./scripts/check.sh`
- `swiftc -frontend -parse swift/Sources/Parakey/main.swift swift/Sources/Parakey/Localization.swift`
- `swift run -c debug --package-path swift Parakey --self-test all` → `PASS all`
- `git diff --check`

The full build compiled both `main.swift` and `Localization.swift` against the pinned FluidAudio revision.